### PR TITLE
fix: serve product images from uploaded media

### DIFF
--- a/src/products/templates/product.html
+++ b/src/products/templates/product.html
@@ -44,7 +44,7 @@
 
       <div class="col-auto d-none d-lg-block">
         {% if product.image %}
-          <img src="{% static product.image %}" width="400" height="400" alt="{{ product.name }}">
+          <img src="{{ product.image.url }}" width="400" height="400" alt="{{ product.name }}">
         {% else %}
           <img src="https://placehold.co/400x400" width="400" height="400" alt="Placeholder">
         {% endif %}
@@ -203,7 +203,7 @@
               <div class="card">
                 {% if other.image %}
                   <img
-                    src="{% static other.image %}"
+                    src="{{ other.image.url }}"
                     class="card-img-top related-img"
                     alt="{{ other.name }}"
                     style="height:160px; width:100%; object-fit:cover; aspect-ratio:16/9;"

--- a/src/products/templates/products.html
+++ b/src/products/templates/products.html
@@ -20,7 +20,7 @@
       <div class="card  mt-3" style="width: 18rem; margin: 0 0.25rem;">
         {% if product.image %}
         {% load static %}
-        <img src="{% static product.image %}" class="card-img-top" width="300" height="230">
+        <img src="{{ product.image.url }}" class="card-img-top" width="300" height="230">
         {% else %}
         <img src="https://placehold.co/300x200" class="card-img-top" width="300" height="230">
         {% endif %}


### PR DESCRIPTION
## Description
Switches product image rendering from static files to uploaded media.

Templates previously resolved images via `{% static product.image %}`, which
only works for files bundled in the static directory. Products with images
uploaded through the `ImageField` (stored under MEDIA) failed to render.

Changed to `{{ product.image.url }}` so the URL comes directly from the
`ImageField`, correctly serving user-uploaded images. The placeholder
fallback for products without an image is unchanged.

## Type of Change
- [x] New feature 

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
