### PR TITLE
fix(seed): serve media files from seed and manual admin upload

### DIFF
--- a/src/btw_app/urls.py
+++ b/src/btw_app/urls.py
@@ -10,14 +10,16 @@ Class-based views
     1. Add an import:  from other_app.views import Home
     2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
 Including another URLconf
-    1. Import the include() function: from django.urls import include, path
+    1. Import the include() function: from django.urls import include, path, re_path
+from django.views.static import serve
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, re_path
+from django.views.static import serve
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -27,4 +29,11 @@ urlpatterns = [
 
 if settings.DEBUG:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+urlpatterns += [
+    re_path(
+        r"^{}(?P<path>.*)$".format(settings.MEDIA_URL.lstrip("/")),
+        serve,
+        {"document_root": settings.MEDIA_ROOT},
+    ),
+]

--- a/src/products/management/commands/seed_db.py
+++ b/src/products/management/commands/seed_db.py
@@ -1,6 +1,15 @@
+import shutil
+from pathlib import Path
+
+from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from products.models import Category, Product
+
+# The product images shipped with the codebase. Product.image resolves against
+# MEDIA_ROOT, but MEDIA_ROOT is git-ignored - so the files are kept here and get
+# copied over when seeding.
+SEED_IMAGE_DIR = Path(settings.BASE_DIR) / "static" / "imgs" / "products"
 
 categories_list = [("boys", "", "boys"), ("girls", "", "girls"), ("toys", "", "toys"), ("outdoor", "", "outdoor")]
 products = [
@@ -142,8 +151,20 @@ class Command(BaseCommand):
         # Create products
         created_products = 0
 
+        copied_images = 0
+
         try:
             for product in products:
+                target = Path(settings.MEDIA_ROOT) / product["image"]
+                if not target.exists():
+                    source = SEED_IMAGE_DIR / Path(product["image"]).name
+                    if source.exists():
+                        target.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(source, target)
+                        copied_images += 1
+                    else:
+                        self.stdout.write(self.style.ERROR(f"Seed image missing: {source}"))
+
                 # Get the category object, if non-existent abort seeding
                 category = Category.objects.filter(name=product["category"]).first()
                 if not category:


### PR DESCRIPTION
## Description

Product images were not rendered in the frontend, neither for products created by the data seed nor for images uploaded manually through the Django admin. This PR fixes both cases.

**Root cause**

1. `Product.image` (`upload_to="imgs/products/"`) resolves against `MEDIA_ROOT` (`src/media/`). The sample images shipped with the repo, however, live in `static/imgs/products/`, and `media/` is git-ignored, so after seeding the files did not exist on disk at all. The result was a 404 on `/media/imgs/products/...`.
2. The media route was only registered inside `if settings.DEBUG:`. The container runs the app with `DEBUG=false`, so `/media/` was not served at all.

**Changes**

- `src/products/management/commands/seed_db.py`: seeding now copies the product images bundled in `static/imgs/products/` into `MEDIA_ROOT`, but only when the target file does not exist yet. The step is therefore idempotent and never overwrites existing uploads. A missing source file is reported as an error on stdout without aborting the seed.
- `src/btw_app/urls.py`: the `/media/` route is registered via `re_path` + `django.views.static.serve` regardless of `DEBUG`, so uploads are also visible inside the container. The static route stays DEBUG-only, since WhiteNoise already serves static files in production.

**Verification**

- `python manage.py seed_db` results in the images being placed in `src/media/imgs/products/`, and the product pages render them.
- Uploading a new product image via `/admin/` makes the image show up on the product page.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
